### PR TITLE
Fix wrong api wrapper being called after minification

### DIFF
--- a/src/apis/accountsApiWrapper.ts
+++ b/src/apis/accountsApiWrapper.ts
@@ -19,6 +19,8 @@ import { DeployRequest } from "../models/deployRequest";
 
 @httpErrorHandler
 export class AccountsApiWrapper extends BaseApiWrapper<AccountsApi> {
+    static type = 'accounts';
+
     constructor(accessToken: string, basePath?: string) {
         super(AccountsApi, accessToken, basePath);
     }

--- a/src/apis/baseApiWrapper.ts
+++ b/src/apis/baseApiWrapper.ts
@@ -5,6 +5,8 @@ import { ConfigurationParameters } from "../generated/configuration";
 import { Middleware } from "../utilities/middleware";
 
 export class BaseApiWrapper<T> implements Observable {
+    static type = 'base';
+
     private readonly _observers: Observer[] = [];
     protected readonly api: T;
 

--- a/src/apis/contractsApiWrapper.ts
+++ b/src/apis/contractsApiWrapper.ts
@@ -14,6 +14,8 @@ import { ReadContractRequest } from "../models/readContractRequest";
 
 @httpErrorHandler
 export class ContractsApiWrapper extends BaseApiWrapper<ContractsApi> {
+    static type = 'contracts';
+
     constructor(accessToken: string, basePath?: string) {
         super(ContractsApi, accessToken, basePath);
     }

--- a/src/apis/eventsApiWrapper.ts
+++ b/src/apis/eventsApiWrapper.ts
@@ -12,6 +12,8 @@ import { GetEventRequest } from "../models/getEventRequest";
 
 @httpErrorHandler
 export class EventsApiWrapper extends BaseApiWrapper<EventsApi> {
+    static type = 'events';
+
     constructor(accessToken: string, basePath?: string) {
         super(EventsApi, accessToken, basePath);
     }

--- a/src/apis/exchangeApiWrapper.ts
+++ b/src/apis/exchangeApiWrapper.ts
@@ -4,6 +4,8 @@ import { httpErrorHandler } from "../utilities/httpErrorHandler";
 
 @httpErrorHandler
 export class ExchangeApiWrapper extends BaseApiWrapper<ExchangeApi> {
+    static type = 'exchange';
+
     constructor(accessToken: string, basePath?: string) {
         super(ExchangeApi, accessToken, basePath);
     }

--- a/src/apis/iamApiWrapper.ts
+++ b/src/apis/iamApiWrapper.ts
@@ -27,6 +27,8 @@ import {
 
 @httpErrorHandler
 export class IamApiWrapper extends BaseApiWrapper<AdminAuthenticationApi> {
+    static type = 'iam';
+
     constructor(accessToken: string, basePath?: string) {
         super(AdminAuthenticationApi, accessToken, basePath);
     }

--- a/src/apis/inventoriesApiWrapper.ts
+++ b/src/apis/inventoriesApiWrapper.ts
@@ -9,6 +9,8 @@ import { GetAccountInventoryRequest } from "../models/getAccountInventoryRequest
 
 @httpErrorHandler
 export class InventoriesApiWrapper extends BaseApiWrapper<InventoriesApi> {
+    static type = 'inventories';
+
     constructor(accessToken: string, basePath?: string) {
         super(InventoriesApi, accessToken, basePath);
     }

--- a/src/apis/payamsterApiWrapper.ts
+++ b/src/apis/payamsterApiWrapper.ts
@@ -6,6 +6,8 @@ import { UpdatePaymasterRequest } from "../models/updatePaymasterRequest";
 
 @httpErrorHandler
 export class PaymasterApiWrapper extends BaseApiWrapper<PaymasterApi> {
+    static type = 'paymaster';
+
     constructor(accessToken: string, basePath?: string) {
         super(PaymasterApi, accessToken, basePath);
     }

--- a/src/apis/playersApiWrapper.ts
+++ b/src/apis/playersApiWrapper.ts
@@ -13,6 +13,8 @@ import { httpErrorHandler } from "../utilities/httpErrorHandler";
 
 @httpErrorHandler
 export class PlayersApiWrapper extends BaseApiWrapper<PlayersApi> {
+    static type = 'players';
+
     constructor(accessToken: string, basePath?: string) {
         super(PlayersApi, accessToken, basePath);
     }

--- a/src/apis/policiesApiWrapper.ts
+++ b/src/apis/policiesApiWrapper.ts
@@ -14,6 +14,8 @@ import { httpErrorHandler } from "../utilities/httpErrorHandler";
 
 @httpErrorHandler
 export class PoliciesApiWrapper extends BaseApiWrapper<PoliciesApi> {
+    static type = 'policies';
+
     constructor(accessToken: string, basePath?: string) {
         super(PoliciesApi, accessToken, basePath);
     }

--- a/src/apis/policyRulesApiWrapper.ts
+++ b/src/apis/policyRulesApiWrapper.ts
@@ -12,6 +12,8 @@ import { httpErrorHandler } from "../utilities/httpErrorHandler";
 
 @httpErrorHandler
 export class PolicyRulesApiWrapper extends BaseApiWrapper<PolicyRulesApi> {
+    static type = 'policyRules';
+
     constructor(accessToken: string, basePath?: string) {
         super(PolicyRulesApi, accessToken, basePath);
     }

--- a/src/apis/sessionsApiWrapper.ts
+++ b/src/apis/sessionsApiWrapper.ts
@@ -13,6 +13,8 @@ import { GetSessionRequest } from "../models/getSessionRequest";
 
 @httpErrorHandler
 export class SessionsApiWrapper extends BaseApiWrapper<SessionsApi> {
+    static type = 'sessions';
+
     constructor(accessToken: string, basePath?: string) {
         super(SessionsApi, accessToken, basePath);
     }

--- a/src/apis/settingsApiWrapper.ts
+++ b/src/apis/settingsApiWrapper.ts
@@ -6,6 +6,8 @@ import { GetDeveloperAccountRequest } from "../models/getDeveloperAccountRequest
 
 @httpErrorHandler
 export class SettingsApiWrapper extends BaseApiWrapper<SettingsApi> {
+    static type = 'settings';
+
     constructor(accessToken: string, basePath?: string) {
         super(SettingsApi, accessToken, basePath);
     }

--- a/src/apis/subscriptionsApiWrapper.ts
+++ b/src/apis/subscriptionsApiWrapper.ts
@@ -11,6 +11,8 @@ import { GetSubscriptionRequest } from "../models/getSubscriptionRequest";
 
 @httpErrorHandler
 export class SubscriptionsApiWrapper extends BaseApiWrapper<SubscriptionsApi> {
+    static type = 'subscriptions';
+
     constructor(accessToken: string, basePath?: string) {
         super(SubscriptionsApi, accessToken, basePath);
     }

--- a/src/apis/transactionIntentsApiWrapper.ts
+++ b/src/apis/transactionIntentsApiWrapper.ts
@@ -13,6 +13,8 @@ import { httpErrorHandler } from "../utilities/httpErrorHandler";
 
 @httpErrorHandler
 export class TransactionIntentsApiWrapper extends BaseApiWrapper<TransactionIntentsApi> {
+    static type = 'transactionIntents';
+
     constructor(accessToken: string, basePath?: string) {
         super(TransactionIntentsApi, accessToken, basePath);
     }

--- a/src/apis/web3ConnectionsApiWrapper.ts
+++ b/src/apis/web3ConnectionsApiWrapper.ts
@@ -15,6 +15,8 @@ import { CreateSubmitWeb3ActionRequest } from "../models/submitWeb3ActionRequest
 
 @httpErrorHandler
 export class Web3ConnectionsApiWrapper extends BaseApiWrapper<Web3ConnectionsApi> {
+    static type = 'web3Connections';
+
     constructor(accessToken: string, basePath?: string) {
         super(Web3ConnectionsApi, accessToken, basePath);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,21 @@ export default class Openfort {
         }
     }
 
+    private getWrapperKey(wrapper: any): string {
+        if ('type' in wrapper && typeof wrapper.type === 'string') {
+            return wrapper.type;
+        }
+
+        if ('name' in wrapper && typeof wrapper.name === 'string') {
+            return wrapper.name;
+        }
+
+        throw new Error('getWrapperKey failed');
+    }
+
     private getOrCreateWrapper<T extends Observable>(type: new (_accessToken: string, _basePath?: string) => T): T {
-        const wrapper = this.apiWrappers[type.name];
+        const key = this.getWrapperKey(type);
+        const wrapper = this.apiWrappers[key];
         if (wrapper) {
             return wrapper as T;
         }
@@ -96,7 +109,7 @@ export default class Openfort {
         for (const observer of this.observers) {
             result.subscribe?.(observer);
         }
-        this.apiWrappers[type.name] = result;
+        this.apiWrappers[key] = result;
         return result;
     }
 


### PR DESCRIPTION
When building projects using this package for production, minification of the package could cause the wrong APIs to be called.

The API wrapper's `name` would collapse from the original full name such as `PlayersApiWrapper` or `TransactionIntentsApiWrapper` down to some minified string such as `l` or `p`. This would in turn cause `getOrCreateWrapper` to fail since it could return other API wrappers when attempting to lookup via `this.apiWrappers`.

This fix adds a new static `type` field to all API wrappers, and attempts to use this field as a key for caching.