### PR TITLE
Reject odd-length Solana hex private keys

### DIFF
--- a/src/wallets/solana/solanaClient.test.ts
+++ b/src/wallets/solana/solanaClient.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { UserInputValidationError } from '../../errors'
+import { SolanaClient } from './solanaClient'
+
+describe('SolanaClient.importAccount', () => {
+  it('rejects odd-length hex private keys before encryption', async () => {
+    const client = new SolanaClient()
+
+    await expect(
+      client.importAccount({ privateKey: `0x${'a'.repeat(63)}` }),
+    ).rejects.toThrow(UserInputValidationError)
+    await expect(
+      client.importAccount({ privateKey: `0x${'a'.repeat(63)}` }),
+    ).rejects.toThrow(
+      'Private key hex string must contain an even number of characters',
+    )
+  })
+})

--- a/src/wallets/solana/solanaClient.ts
+++ b/src/wallets/solana/solanaClient.ts
@@ -225,9 +225,19 @@ export class SolanaClient {
       if (!/^[0-9a-fA-F]+$/.test(hex)) {
         throw new UserInputValidationError('Invalid hex string')
       }
+      if (hex.length % 2 !== 0) {
+        throw new UserInputValidationError(
+          'Private key hex string must contain an even number of characters',
+        )
+      }
       privateKeyBytes = Uint8Array.from(Buffer.from(hex, 'hex'))
     } else if (/^[0-9a-fA-F]+$/.test(options.privateKey)) {
       // Hex format without prefix
+      if (options.privateKey.length % 2 !== 0) {
+        throw new UserInputValidationError(
+          'Private key hex string must contain an even number of characters',
+        )
+      }
       privateKeyBytes = Uint8Array.from(Buffer.from(options.privateKey, 'hex'))
     } else {
       // Assume base58 format (standard Solana format)


### PR DESCRIPTION
Rejects odd-length hex strings in Solana private-key import before decoding them with `Buffer.from(..., "hex")`.

Node truncates a trailing half-byte when decoding odd-length hex, so a malformed key could be decoded into a different byte array and then fail later with a misleading key-length error. This makes the validation explicit for both `0x`-prefixed and plain hex input.

Checked with:
- `pnpm install --ignore-scripts --frozen-lockfile`
- `pnpm test src/wallets/solana/solanaClient.test.ts`
- `pnpm check:types`
- `pnpm lint`
- `pnpm build`
- `git diff --check`