### PR TITLE
FIX: gate EIP-7702 authorization signing on on-chain delegation

### DIFF
--- a/.changeset/yummy-rats-joke.md
+++ b/.changeset/yummy-rats-joke.md
@@ -1,0 +1,5 @@
+---
+"@openfort/openfort-node": patch
+---
+
+gate EIP-7702 authorization when EOA not delegated on-chain

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,15 @@
  */
 
 /**
+ * Calibur implementation contract address used for EIP-7702 delegation.
+ *
+ * An EOA delegated to this implementation has on-chain code equal to the
+ * EIP-7702 designator `0xef0100 || <this address>`.
+ */
+export const CALIBUR_IMPLEMENTATION_ADDRESS =
+  '0x000000009b1d0af20d8c6d0a44e162d11f9b8f00'
+
+/**
  * Server's RSA-4096 public key for import encryption.
  *
  * This key is used to encrypt private keys before sending them to the server

--- a/src/wallets/evm/actions/sendTransaction.test.ts
+++ b/src/wallets/evm/actions/sendTransaction.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EvmAccount, SendTransactionOptions } from '../types'
+
+// Shared mocks (hoisted so vi.mock factories can reference them).
+const mocks = vi.hoisted(() => ({
+  getAccountsV2: vi.fn(),
+  createTransactionIntent: vi.fn(),
+  submitSignature: vi.fn(),
+  update: vi.fn(),
+  getCode: vi.fn(),
+  getTransactionCount: vi.fn(),
+  hashAuthorization: vi.fn(),
+}))
+
+vi.mock('../../../openapi-client', () => ({
+  getAccountsV2: mocks.getAccountsV2,
+  createTransactionIntent: mocks.createTransactionIntent,
+  signature: mocks.submitSignature,
+}))
+
+vi.mock('./updateToDelegated', () => ({ update: mocks.update }))
+
+vi.mock('viem', () => ({
+  http: vi.fn(() => ({})),
+  getAddress: (a: string) => a,
+  createPublicClient: vi.fn(() => ({
+    getCode: mocks.getCode,
+    getTransactionCount: mocks.getTransactionCount,
+  })),
+}))
+
+vi.mock('viem/chains', () => ({ baseSepolia: { id: 84532 } }))
+
+vi.mock('viem/utils', () => ({ hashAuthorization: mocks.hashAuthorization }))
+
+// Imported after mocks are registered.
+const { sendTransaction } = await import('./sendTransaction')
+
+const CALIBUR = '0x000000009b1d0af20d8c6d0a44e162d11f9b8f00'
+const DESIGNATOR = `0xef0100${CALIBUR.slice(2)}`
+
+function makeAccount() {
+  return {
+    id: 'acc_eoa',
+    address: '0xb4527c24a393db150d1d8bac93c51f9ad7b6480a',
+    walletId: 'pla_x',
+    sign: vi.fn(async () => '0xsignature'),
+  }
+}
+
+const opts = (
+  account: ReturnType<typeof makeAccount>,
+): SendTransactionOptions => ({
+  account: account as unknown as EvmAccount,
+  chainId: 84532,
+  interactions: [{ to: '0xUSDC', data: '0xdeadbeef' }],
+  policy: 'pol_x',
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.hashAuthorization.mockReturnValue('0xauthhash')
+  mocks.getTransactionCount.mockResolvedValue(0)
+  mocks.createTransactionIntent.mockResolvedValue({
+    id: 'tin_x',
+    nextAction: null,
+  })
+  mocks.submitSignature.mockResolvedValue({ id: 'tin_x' })
+})
+
+describe('sendTransaction — EIP-7702 authorization gating', () => {
+  it('signs the authorization when a delegated record exists but the EOA is NOT delegated on-chain (stale-record regression)', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [{ id: 'acc_del' }] })
+    mocks.getCode.mockResolvedValue('0x') // bare EOA on-chain despite the DB record
+
+    const account = makeAccount()
+    await sendTransaction(opts(account))
+
+    expect(mocks.update).not.toHaveBeenCalled() // reuse existing record, don't recreate
+    expect(account.sign).toHaveBeenCalledWith({ hash: '0xauthhash' })
+    const intentArg = mocks.createTransactionIntent.mock.calls[0][0]
+    expect(intentArg.account).toBe('acc_del')
+    expect(intentArg.signedAuthorization).toBe('0xsignature') // <- the fix
+  })
+
+  it('does NOT re-sign the authorization when the EOA is already delegated on-chain to Calibur', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [{ id: 'acc_del' }] })
+    mocks.getCode.mockResolvedValue(DESIGNATOR)
+
+    const account = makeAccount()
+    await sendTransaction(opts(account))
+
+    expect(mocks.hashAuthorization).not.toHaveBeenCalled()
+    expect(
+      mocks.createTransactionIntent.mock.calls[0][0].signedAuthorization,
+    ).toBeUndefined()
+  })
+
+  it('matches the on-chain designator case-insensitively', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [{ id: 'acc_del' }] })
+    mocks.getCode.mockResolvedValue(`0xEF0100${CALIBUR.slice(2).toUpperCase()}`)
+
+    const account = makeAccount()
+    await sendTransaction(opts(account))
+
+    expect(
+      mocks.createTransactionIntent.mock.calls[0][0].signedAuthorization,
+    ).toBeUndefined()
+  })
+
+  it('rejects a non-https rpcUrl (SSRF/scheme guard)', async () => {
+    const account = makeAccount()
+    await expect(
+      sendTransaction({ ...opts(account), rpcUrl: 'http://evil.internal' }),
+    ).rejects.toThrow(/rpcUrl must use https/)
+    expect(account.sign).not.toHaveBeenCalled()
+    expect(mocks.getCode).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed rpcUrl', async () => {
+    const account = makeAccount()
+    await expect(
+      sendTransaction({ ...opts(account), rpcUrl: 'not a url' }),
+    ).rejects.toThrow(/Invalid rpcUrl/)
+  })
+
+  it('allows http only for loopback (local dev nodes)', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [{ id: 'acc_del' }] })
+    mocks.getCode.mockResolvedValue(DESIGNATOR)
+
+    const account = makeAccount()
+    await expect(
+      sendTransaction({ ...opts(account), rpcUrl: 'http://127.0.0.1:8545' }),
+    ).resolves.toBeDefined()
+  })
+
+  it('registers a delegated record and signs the authorization on first send (no record yet)', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [] })
+    mocks.update.mockResolvedValue({ id: 'acc_new_del' })
+    mocks.getCode.mockResolvedValue(undefined) // viem returns undefined for empty code
+
+    const account = makeAccount()
+    await sendTransaction(opts(account))
+
+    expect(mocks.update).toHaveBeenCalled()
+    const intentArg = mocks.createTransactionIntent.mock.calls[0][0]
+    expect(intentArg.account).toBe('acc_new_del')
+    expect(intentArg.signedAuthorization).toBe('0xsignature')
+  })
+})

--- a/src/wallets/evm/actions/sendTransaction.test.ts
+++ b/src/wallets/evm/actions/sendTransaction.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CALIBUR_IMPLEMENTATION_ADDRESS } from '../../../constants'
 import type { EvmAccount, SendTransactionOptions } from '../types'
 
 // Shared mocks (hoisted so vi.mock factories can reference them).
@@ -36,7 +37,7 @@ vi.mock('viem/utils', () => ({ hashAuthorization: mocks.hashAuthorization }))
 // Imported after mocks are registered.
 const { sendTransaction } = await import('./sendTransaction')
 
-const CALIBUR = '0x000000009b1d0af20d8c6d0a44e162d11f9b8f00'
+const CALIBUR = CALIBUR_IMPLEMENTATION_ADDRESS
 const DESIGNATOR = `0xef0100${CALIBUR.slice(2)}`
 
 function makeAccount() {
@@ -81,6 +82,41 @@ describe('sendTransaction — EIP-7702 authorization gating', () => {
     const intentArg = mocks.createTransactionIntent.mock.calls[0][0]
     expect(intentArg.account).toBe('acc_del')
     expect(intentArg.signedAuthorization).toBe('0xsignature') // <- the fix
+  })
+
+  it('uses the implementation address from the account record, not the hardcoded fallback', async () => {
+    const apiImpl = '0x00000000000000000000000000000000deadbeef'
+    mocks.getAccountsV2.mockResolvedValue({
+      data: [
+        { id: 'acc_del', smartAccount: { implementationAddress: apiImpl } },
+      ],
+    })
+    mocks.getCode.mockResolvedValue('0x') // not delegated -> must sign
+
+    const account = makeAccount()
+    await sendTransaction(opts(account))
+
+    expect(mocks.hashAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({ contractAddress: apiImpl }),
+    )
+  })
+
+  it('treats the EOA as delegated when on-chain code matches the record implementation', async () => {
+    const apiImpl = '0x00000000000000000000000000000000deadbeef'
+    mocks.getAccountsV2.mockResolvedValue({
+      data: [
+        { id: 'acc_del', smartAccount: { implementationAddress: apiImpl } },
+      ],
+    })
+    mocks.getCode.mockResolvedValue(`0xef0100${apiImpl.slice(2)}`)
+
+    const account = makeAccount()
+    await sendTransaction(opts(account))
+
+    expect(mocks.hashAuthorization).not.toHaveBeenCalled()
+    expect(
+      mocks.createTransactionIntent.mock.calls[0][0].signedAuthorization,
+    ).toBeUndefined()
   })
 
   it('does NOT re-sign the authorization when the EOA is already delegated on-chain to Calibur', async () => {
@@ -132,6 +168,22 @@ describe('sendTransaction — EIP-7702 authorization gating', () => {
     await expect(
       sendTransaction({ ...opts(account), rpcUrl: 'http://127.0.0.1:8545' }),
     ).resolves.toBeDefined()
+  })
+
+  it('fails open and signs the authorization when the on-chain code read throws (RPC error)', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [{ id: 'acc_del' }] })
+    mocks.getCode.mockRejectedValue(new Error('RPC down'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const account = makeAccount()
+    await sendTransaction(opts(account))
+
+    expect(account.sign).toHaveBeenCalledWith({ hash: '0xauthhash' })
+    expect(
+      mocks.createTransactionIntent.mock.calls[0][0].signedAuthorization,
+    ).toBe('0xsignature')
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
   })
 
   it('registers a delegated record and signs the authorization on first send (no record yet)', async () => {

--- a/src/wallets/evm/actions/sendTransaction.ts
+++ b/src/wallets/evm/actions/sendTransaction.ts
@@ -14,8 +14,9 @@ import { update } from './updateToDelegated'
 /**
  * Delegates an EVM account via EIP-7702 and sends a gasless transaction in one call.
  *
- * Internally: registers delegation -> fetches EOA nonce via RPC -> hashes and signs
- * EIP-7702 authorization -> creates transaction intent -> signs and submits if needed.
+ * Internally: ensures a delegated-account record -> checks on-chain delegation via
+ * eth_getCode -> if the EOA is not delegated on-chain, hashes and signs an EIP-7702
+ * authorization -> creates transaction intent -> signs and submits if needed.
  *
  * @param options - Transaction options including account ID, chain, interactions, and optional policy
  * @returns The transaction intent response
@@ -62,6 +63,27 @@ export async function sendTransaction(
   const { account, chainId, interactions, policy, rpcUrl } = options
 
   // 1. Resolve chain + RPC
+  // This RPC gates EIP-7702 authorization signing, so require a trusted scheme:
+  // https everywhere, http only for loopback (local dev nodes like anvil).
+  if (rpcUrl !== undefined) {
+    let parsed: URL
+    try {
+      parsed = new URL(rpcUrl)
+    } catch {
+      throw new UserInputValidationError(`Invalid rpcUrl: ${rpcUrl}`)
+    }
+    const isLoopback = ['localhost', '127.0.0.1', '[::1]'].includes(
+      parsed.hostname,
+    )
+    if (
+      parsed.protocol !== 'https:' &&
+      !(parsed.protocol === 'http:' && isLoopback)
+    ) {
+      throw new UserInputValidationError(
+        'rpcUrl must use https (http allowed only for localhost).',
+      )
+    }
+  }
   const transport = rpcUrl ? viem.http(rpcUrl) : viem.http()
   const allChains = Object.values(viemChains)
   const chain = allChains.find(
@@ -77,19 +99,23 @@ export async function sendTransaction(
     )
   }
 
-  // 2. Get or create delegated account
-  let signedAuthorization: string | undefined
-  let txAccountId: string
+  // 2. Resolve the delegated-account record, then decide whether to (re)sign the
+  //    EIP-7702 authorization based on ACTUAL on-chain delegation state.
+  const implementationAddress: Hex =
+    '0x000000009b1d0af20d8c6d0a44e162d11f9b8f00'
+  const publicClient = viem.createPublicClient({ chain, transport })
+  const eoaAddress = viem.getAddress(account.address)
 
   const response = await getAccountsV2({
-    address: viem.getAddress(account.address),
+    address: eoaAddress,
     accountType: 'Delegated Account',
     chainType: 'EVM',
     chainId: chainId,
   })
 
+  let txAccountId: string
   if (response.data.length === 0) {
-    // No delegation yet - register it
+    // No delegated-account record yet - register one.
     const updated = await update({
       walletId: account.walletId,
       chainId,
@@ -97,13 +123,20 @@ export async function sendTransaction(
       accountId: account.id,
     })
     txAccountId = updated.id
+  } else {
+    txAccountId = response.data[0].id
+  }
 
-    const implementationAddress: Hex =
-      '0x000000009b1d0af20d8c6d0a44e162d11f9b8f00'
-
-    const publicClient = viem.createPublicClient({ chain, transport })
-
-    // 2.1. Sign EIP-7702 authorization if not yet delegated on-chain
+  // TRANSITIONAL: stale records can read delegated while the EOA is bare on-chain
+  // (code === '0x'), causing AA34. Gate signing on actual on-chain state until the
+  // API backfill makes the DB authoritative, then REMOVE this getCode call and
+  // trust the record alone (no RPC).
+  let signedAuthorization: string | undefined
+  const code = await publicClient.getCode({ address: eoaAddress })
+  const delegationDesignator =
+    `0xef0100${implementationAddress.slice(2)}`.toLowerCase()
+  const isDelegatedOnChain = code?.toLowerCase() === delegationDesignator
+  if (!isDelegatedOnChain) {
     const eoaNonce = await publicClient.getTransactionCount({
       address: account.address,
     })
@@ -113,8 +146,6 @@ export async function sendTransaction(
       nonce: eoaNonce,
     })
     signedAuthorization = await account.sign({ hash: authHash })
-  } else {
-    txAccountId = response.data[0].id
   }
 
   // 3. Create transaction intent

--- a/src/wallets/evm/actions/sendTransaction.ts
+++ b/src/wallets/evm/actions/sendTransaction.ts
@@ -1,9 +1,11 @@
+import { CALIBUR_IMPLEMENTATION_ADDRESS } from '../../../constants'
 import { DelegationError, UserInputValidationError } from '../../../errors'
 import {
   createTransactionIntent,
   getAccountsV2,
   signature as submitSignature,
 } from '../../../openapi-client'
+import { isDelegatedTo } from '../delegation'
 import type {
   Hash,
   Hex,
@@ -101,8 +103,6 @@ export async function sendTransaction(
 
   // 2. Resolve the delegated-account record, then decide whether to (re)sign the
   //    EIP-7702 authorization based on ACTUAL on-chain delegation state.
-  const implementationAddress: Hex =
-    '0x000000009b1d0af20d8c6d0a44e162d11f9b8f00'
   const publicClient = viem.createPublicClient({ chain, transport })
   const eoaAddress = viem.getAddress(account.address)
 
@@ -113,7 +113,11 @@ export async function sendTransaction(
     chainId: chainId,
   })
 
+  // Take the implementation address from the account record (the backend's source
+  // of truth) so the signed authorization and the on-chain check match what the
+  // platform registered. Fall back to the known Calibur address if absent.
   let txAccountId: string
+  let implementationAddress: Hex
   if (response.data.length === 0) {
     // No delegated-account record yet - register one.
     const updated = await update({
@@ -123,8 +127,15 @@ export async function sendTransaction(
       accountId: account.id,
     })
     txAccountId = updated.id
+    implementationAddress =
+      (updated.smartAccount?.implementationAddress as Hex | undefined) ??
+      CALIBUR_IMPLEMENTATION_ADDRESS
   } else {
     txAccountId = response.data[0].id
+    implementationAddress =
+      (response.data[0].smartAccount?.implementationAddress as
+        | Hex
+        | undefined) ?? CALIBUR_IMPLEMENTATION_ADDRESS
   }
 
   // TRANSITIONAL: stale records can read delegated while the EOA is bare on-chain
@@ -132,11 +143,21 @@ export async function sendTransaction(
   // API backfill makes the DB authoritative, then REMOVE this getCode call and
   // trust the record alone (no RPC).
   let signedAuthorization: string | undefined
-  const code = await publicClient.getCode({ address: eoaAddress })
-  const delegationDesignator =
-    `0xef0100${implementationAddress.slice(2)}`.toLowerCase()
-  const isDelegatedOnChain = code?.toLowerCase() === delegationDesignator
-  if (!isDelegatedOnChain) {
+  // Fail open: if the on-chain code is unreadable (RPC error), sign the
+  // authorization anyway. Re-delegating an already-delegated EOA is harmless,
+  // but skipping a needed authorization reverts on-chain with AA34.
+  let delegatedOnChain = false
+  try {
+    const code = await publicClient.getCode({ address: eoaAddress })
+    delegatedOnChain = isDelegatedTo(code, implementationAddress)
+  } catch (error) {
+    // biome-ignore lint/suspicious/noConsole: a fallback notice belongs on stderr (warn), not stdout (log).
+    console.warn(
+      '[Openfort] Could not read on-chain code for EIP-7702 delegation check; signing authorization anyway.',
+      error,
+    )
+  }
+  if (!delegatedOnChain) {
     const eoaNonce = await publicClient.getTransactionCount({
       address: account.address,
     })

--- a/src/wallets/evm/delegation.test.ts
+++ b/src/wallets/evm/delegation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { getDelegationTarget, isDelegatedTo } from './delegation'
+import type { Hex } from './types'
+
+const IMPL = '0x00000000000000000000000000000000deadbeef' as Hex
+const DESIGNATOR = `0xef0100${IMPL.slice(2)}` as Hex
+
+describe('getDelegationTarget', () => {
+  it('extracts the lowercase target from a valid designator', () => {
+    expect(getDelegationTarget(DESIGNATOR)).toBe(IMPL.toLowerCase())
+  })
+
+  it('is case-insensitive about the prefix and address', () => {
+    const upper = `0xEF0100${IMPL.slice(2).toUpperCase()}` as Hex
+    expect(getDelegationTarget(upper)).toBe(IMPL.toLowerCase())
+  })
+
+  it('returns null for a bare EOA (undefined or 0x)', () => {
+    expect(getDelegationTarget(undefined)).toBeNull()
+    expect(getDelegationTarget('0x')).toBeNull()
+  })
+
+  it('returns null for a regular contract (wrong length)', () => {
+    expect(getDelegationTarget('0x6080604052348015' as Hex)).toBeNull()
+  })
+
+  it('returns null when the length is right but the prefix does not match', () => {
+    const wrongPrefix = `0xdeadbe${IMPL.slice(2)}` as Hex
+    expect(getDelegationTarget(wrongPrefix)).toBeNull()
+  })
+})
+
+describe('isDelegatedTo', () => {
+  it('is true only when delegated to the expected implementation', () => {
+    expect(isDelegatedTo(DESIGNATOR, IMPL)).toBe(true)
+  })
+
+  it('is false when delegated to a different implementation', () => {
+    const other = '0x000000000000000000000000000000000000beef' as Hex
+    expect(isDelegatedTo(`0xef0100${other.slice(2)}` as Hex, IMPL)).toBe(false)
+  })
+
+  it('matches regardless of implementation address casing', () => {
+    expect(isDelegatedTo(DESIGNATOR, IMPL.toUpperCase() as Hex)).toBe(true)
+  })
+
+  it('is false for a bare EOA', () => {
+    expect(isDelegatedTo(undefined, IMPL)).toBe(false)
+    expect(isDelegatedTo('0x', IMPL)).toBe(false)
+  })
+})

--- a/src/wallets/evm/delegation.ts
+++ b/src/wallets/evm/delegation.ts
@@ -1,0 +1,59 @@
+/**
+ * @module Wallets/EVM/Delegation
+ * Helpers for inspecting an EOA's on-chain EIP-7702 delegation state.
+ */
+
+import type { Hex } from './types'
+
+/**
+ * The 3-byte prefix that marks an account's on-chain code as an EIP-7702
+ * delegation designator.
+ *
+ * When an EOA delegates execution under EIP-7702, its code is set to exactly
+ * this prefix followed by the 20-byte address of the contract it delegates to,
+ * for a total of 23 bytes (`0xef0100 ‖ address`). A plain EOA has no code and a
+ * regular contract has arbitrary code, so this prefix uniquely identifies a
+ * delegated account.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-7702
+ */
+export const EIP_7702_DELEGATION_PREFIX = '0xef0100'
+
+/**
+ * Hex string length of a full designator: `0x` + 3-byte prefix (6 hex chars) +
+ * 20-byte address (40 hex chars).
+ */
+const DESIGNATOR_HEX_LENGTH = 2 + 6 + 40
+
+/**
+ * Extract the contract address an EOA delegates to under EIP-7702.
+ *
+ * @param code - The account's on-chain bytecode, as returned by `eth_getCode`.
+ *   `undefined` or `0x` means a plain EOA with no code.
+ * @returns The lowercase delegation target address, or `null` when `code` is
+ *   not a valid EIP-7702 delegation designator (an empty EOA or a regular
+ *   contract).
+ */
+export function getDelegationTarget(code: Hex | undefined): Hex | null {
+  if (!code) return null
+  const normalized = code.toLowerCase()
+  if (normalized.length !== DESIGNATOR_HEX_LENGTH) return null
+  if (!normalized.startsWith(EIP_7702_DELEGATION_PREFIX)) return null
+  return `0x${normalized.slice(EIP_7702_DELEGATION_PREFIX.length)}` as Hex
+}
+
+/**
+ * Whether the EOA is currently delegated on-chain to `implementationAddress`.
+ *
+ * Compares the on-chain delegation target against the expected implementation
+ * case-insensitively, so a `true` result means no new authorization is needed.
+ *
+ * @param code - The account's on-chain bytecode, as returned by `eth_getCode`.
+ * @param implementationAddress - The implementation the EOA should delegate to.
+ */
+export function isDelegatedTo(
+  code: Hex | undefined,
+  implementationAddress: Hex,
+): boolean {
+  return getDelegationTarget(code) === implementationAddress.toLowerCase()
+}


### PR DESCRIPTION

## Summary

Backend wallet EVM transactions could repeatedly fail with:

```text
AA34 signature error
```

Once an account encountered this failure, all subsequent transactions from the same account would fail with the same error, effectively preventing the account from sending transactions.

## Root Cause

`sendTransaction` determined whether an EIP-7702 authorization needed to be signed based on the existence of a **Delegated Account** platform record (`getAccountsV2.length > 0`).

This assumption was incorrect because the platform record is persisted **before** the on-chain delegation transaction is confirmed.

As a result, the following failure scenario was possible:

1. A Delegated Account record is created and stored.
2. The delegation transaction has not yet been mined, so the EOA still has no delegated code on-chain.
3. `sendTransaction` sees the existing record and assumes delegation is already active.
4. No `signedAuthorization` is generated.
5. The server constructs a UserOperation using a placeholder authorization.
6. The operation reverts with `AA34 signature error`.

Because the delegation never successfully completed, the platform record remained present. Every subsequent transaction repeated the same logic and failed in the same way, leaving the account permanently stuck in a failure loop.

## Change

Authorization signing is now determined from **actual on-chain state** rather than platform metadata.

Before sending a transaction, the client:

1. Calls `eth_getCode` for the EOA.

2. Checks whether the account is delegated to the Calibur implementation designator:

   ```text
   0xef0100…9b8f00
   ```

3. Generates and signs a fresh EIP-7702 authorization whenever the account is not currently delegated, regardless of whether a Delegated Account record already exists.

The Delegated Account record is still created and maintained as before, but it no longer controls authorization-signing behavior.

## Additional Details

* Designator comparisons are performed case-insensitively.
* `undefined` code responses returned by viem (representing an undelegated account) are treated as **not delegated**.
* Authorization signing is now driven exclusively by on-chain delegation status, eliminating the stale-record failure mode and preventing accounts from becoming permanently stuck.
