### PR TITLE
Fix webhook signature hex validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -931,6 +931,9 @@ class Openfort {
     signature: string,
   ): Promise<T> {
     const signedPayload = await sign(this._apiKey, body)
+    if (!/^[\da-f]+$/iu.test(signature)) {
+      throw new Error('Invalid signature')
+    }
     const expectedBuffer = Buffer.from(signedPayload, 'hex')
     const receivedBuffer = Buffer.from(signature, 'hex')
     if (

--- a/src/webhook.test.ts
+++ b/src/webhook.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import Openfort from './index'
+import { sign } from './utilities/signer'
+
+describe('constructWebhookEvent', () => {
+  it('should reject malformed hex signatures', async () => {
+    const client = new Openfort('sk_test_1234567890')
+    const body = JSON.stringify({ type: 'test.event' })
+    const validSignature = await sign('sk_test_1234567890', body)
+
+    await expect(
+      client.constructWebhookEvent(body, `${validSignature.slice(0, -1)}z`),
+    ).rejects.toThrow('Invalid signature')
+  })
+})


### PR DESCRIPTION
Fixes webhook signature validation so malformed hex signatures are rejected before comparison. Adds regression coverage for invalid hex input.