### PR TITLE
Validate signature recovery byte

### DIFF
--- a/src/wallets/evm/actions/normalizeSignature.test.ts
+++ b/src/wallets/evm/actions/normalizeSignature.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeSignature } from './normalizeSignature'
+
+const signatureWithV = (v: string) => `0x${'11'.repeat(64)}${v}`
+
+describe('normalizeSignature', () => {
+  it('normalizes 0 and 1 recovery ids', () => {
+    expect(normalizeSignature(signatureWithV('00'))).toBe(signatureWithV('1b'))
+    expect(normalizeSignature(signatureWithV('01'))).toBe(signatureWithV('1c'))
+  })
+
+  it('keeps already normalized recovery ids', () => {
+    expect(normalizeSignature(signatureWithV('1b'))).toBe(signatureWithV('1b'))
+  })
+
+  it('rejects signatures without a valid final byte', () => {
+    expect(() => normalizeSignature('0x')).toThrow('Invalid signature')
+    expect(() => normalizeSignature(signatureWithV('zz'))).toThrow(
+      'Invalid signature',
+    )
+  })
+})

--- a/src/wallets/evm/actions/normalizeSignature.ts
+++ b/src/wallets/evm/actions/normalizeSignature.ts
@@ -9,9 +9,14 @@
  * @returns The signature with a corrected `v` byte
  */
 export function normalizeSignature(sig: string): string {
-  const v = parseInt(sig.slice(-2), 16)
+  const vByte = sig.slice(-2)
+  if (!/^[\da-fA-F]{2}$/.test(vByte)) {
+    throw new Error('Invalid signature recovery byte')
+  }
+
+  const v = Number.parseInt(vByte, 16)
   if (v < 27) {
-    return sig.slice(0, -2) + (v + 27).toString(16)
+    return sig.slice(0, -2) + (v + 27).toString(16).padStart(2, '0')
   }
   return sig
 }


### PR DESCRIPTION
`normalizeSignature` used partial hex parsing for the recovery byte, so malformed trailing bytes could be treated as normalized signatures instead of failing.

This validates that the final byte is exactly two hex characters before parsing it, keeps valid 27/28 signatures unchanged, and preserves normalization for 0/1 recovery ids.
