### PR TITLE
chore: standardize Openfort/Shield env var names

### DIFF
--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,5 +1,5 @@
 # Openfort API Key (required)
-OPENFORT_API_KEY=sk_test_...
+OPENFORT_SECRET_KEY=sk_test_...
 OPENFORT_PUBLISHABLE_KEY=pk_test_...
 # Optional: Custom API base URL
 # OPENFORT_BASE_URL=https://api.openfort.io
@@ -11,6 +11,6 @@ OPENFORT_PUBLISHABLE_KEY=pk_test_...
 CHAIN_ID=80002
 
 # Shield Configuration (required for evm/embedded/pregenerate.ts)
-SHIELD_API_KEY=your_shield_api_key
-SHIELD_API_SECRET=your_shield_api_secret
-SHIELD_ENCRYPTION_SHARE=your_encryption_share
+SHIELD_PUBLISHABLE_KEY=your_shield_api_key
+SHIELD_SECRET_KEY=your_shield_api_secret
+SHIELD_ENCRYPTION_KEY=your_encryption_share

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ cp .env.example .env
 
 3. Edit `.env` with your Openfort API key:
 ```bash
-OPENFORT_API_KEY=sk_test_...
+OPENFORT_SECRET_KEY=sk_test_...
 CHAIN_ID=80002  # Polygon Amoy testnet
 ```
 
@@ -79,9 +79,9 @@ pnpm example evm/accounts/createAccount.ts
 | `pregenerate.ts` | Pre-generate a user with embedded wallet |
 
 > **Note:** The `pregenerate.ts` example requires Shield configuration. See `.env.example` for required environment variables:
-> - `SHIELD_API_KEY`
-> - `SHIELD_API_SECRET`
-> - `SHIELD_ENCRYPTION_SHARE`
+> - `SHIELD_PUBLISHABLE_KEY`
+> - `SHIELD_SECRET_KEY`
+> - `SHIELD_ENCRYPTION_KEY`
 
 ### Solana Wallet Examples
 

--- a/examples/evm/accounts/createAccount.ts
+++ b/examples/evm/accounts/createAccount.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/evm/accounts/exportAccount.ts
+++ b/examples/evm/accounts/exportAccount.ts
@@ -4,7 +4,7 @@ import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/evm/accounts/getAccount.ts
+++ b/examples/evm/accounts/getAccount.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/evm/accounts/importAccount.ts
+++ b/examples/evm/accounts/importAccount.ts
@@ -4,7 +4,7 @@ import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/evm/accounts/listAccounts.ts
+++ b/examples/evm/accounts/listAccounts.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/evm/contracts/createContract.ts
+++ b/examples/evm/contracts/createContract.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/contracts/listContracts.ts
+++ b/examples/evm/contracts/listContracts.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/delegation/sendTransaction.ts
+++ b/examples/evm/delegation/sendTransaction.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config'
 import Openfort from '@openfort/openfort-node'
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   walletSecret: process.env.OPENFORT_WALLET_SECRET!,
 })
 

--- a/examples/evm/embedded/pregenerate.ts
+++ b/examples/evm/embedded/pregenerate.ts
@@ -3,7 +3,7 @@
 import Openfort, { ShieldAuthProvider } from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 
@@ -15,10 +15,10 @@ const result = await openfort.accounts.evm.embedded.pregenerate(
     accountType: "Externally Owned Account"
   },
   {
-    shieldApiKey: process.env.SHIELD_API_KEY!,
-    shieldApiSecret: process.env.SHIELD_API_SECRET!,
+    shieldApiKey: process.env.SHIELD_PUBLISHABLE_KEY!,
+    shieldApiSecret: process.env.SHIELD_SECRET_KEY!,
     shieldAuthProvider: ShieldAuthProvider.OPENFORT,
-    encryptionShare: process.env.SHIELD_ENCRYPTION_SHARE!,
+    encryptionShare: process.env.SHIELD_ENCRYPTION_KEY!,
   }
 );
 

--- a/examples/evm/policies/createAccountPolicy.ts
+++ b/examples/evm/policies/createAccountPolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/policies/createProjectPolicy.ts
+++ b/examples/evm/policies/createProjectPolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/policies/deletePolicy.ts
+++ b/examples/evm/policies/deletePolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/policies/getPolicyById.ts
+++ b/examples/evm/policies/getPolicyById.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/policies/listAccountPolicies.ts
+++ b/examples/evm/policies/listAccountPolicies.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/policies/listPolicies.ts
+++ b/examples/evm/policies/listPolicies.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/policies/listProjectPolicies.ts
+++ b/examples/evm/policies/listProjectPolicies.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/policies/signTypedDataPolicy.ts
+++ b/examples/evm/policies/signTypedDataPolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/policies/updatePolicy.ts
+++ b/examples/evm/policies/updatePolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/signing/signHash.ts
+++ b/examples/evm/signing/signHash.ts
@@ -4,7 +4,7 @@ import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 import { keccak256, toBytes } from "viem";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/evm/signing/signMessage.ts
+++ b/examples/evm/signing/signMessage.ts
@@ -4,7 +4,7 @@ import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 import { verifyMessage } from "viem";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/evm/signing/signTransaction.ts
+++ b/examples/evm/signing/signTransaction.ts
@@ -4,7 +4,7 @@ import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 import { parseEther, parseTransaction } from "viem";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/evm/signing/signTypedData.ts
+++ b/examples/evm/signing/signTypedData.ts
@@ -4,7 +4,7 @@ import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 import { verifyTypedData } from "viem";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/evm/transactionIntents/createTransactionIntent.ts
+++ b/examples/evm/transactionIntents/createTransactionIntent.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/transactionIntents/estimateGas.ts
+++ b/examples/evm/transactionIntents/estimateGas.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/transactionIntents/getTransactionIntent.ts
+++ b/examples/evm/transactionIntents/getTransactionIntent.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/transactionIntents/listTransactionIntents.ts
+++ b/examples/evm/transactionIntents/listTransactionIntents.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/evm/transactions/sendTransaction.ts
+++ b/examples/evm/transactions/sendTransaction.ts
@@ -3,7 +3,7 @@
 import 'dotenv/config'
 import Openfort from '@openfort/openfort-node'
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   walletSecret: process.env.OPENFORT_WALLET_SECRET!,
 })
 

--- a/examples/fee-sponsorship/createPolicy.ts
+++ b/examples/fee-sponsorship/createPolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/fee-sponsorship/disableEnablePolicy.ts
+++ b/examples/fee-sponsorship/disableEnablePolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/fee-sponsorship/getPolicy.ts
+++ b/examples/fee-sponsorship/getPolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/fee-sponsorship/listPolicies.ts
+++ b/examples/fee-sponsorship/listPolicies.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/fee-sponsorship/updatePolicy.ts
+++ b/examples/fee-sponsorship/updatePolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/iam/deleteUser.ts
+++ b/examples/iam/deleteUser.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/iam/getSession.ts
+++ b/examples/iam/getSession.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   publishableKey: process.env.OPENFORT_PUBLISHABLE_KEY,
 });

--- a/examples/iam/getUser.ts
+++ b/examples/iam/getUser.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/iam/listUsers.ts
+++ b/examples/iam/listUsers.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/solana/accounts/createAccount.ts
+++ b/examples/solana/accounts/createAccount.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/solana/accounts/exportAccount.ts
+++ b/examples/solana/accounts/exportAccount.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/solana/accounts/getAccount.ts
+++ b/examples/solana/accounts/getAccount.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });
 

--- a/examples/solana/accounts/importAccount.ts
+++ b/examples/solana/accounts/importAccount.ts
@@ -7,7 +7,7 @@ import {
 } from "@solana/kit";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/solana/accounts/listAccounts.ts
+++ b/examples/solana/accounts/listAccounts.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/solana/policies/createSolAllowlistPolicy.ts
+++ b/examples/solana/policies/createSolAllowlistPolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/solana/policies/createSolMessagePolicy.ts
+++ b/examples/solana/policies/createSolMessagePolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/solana/policies/createSplTokenLimitsPolicy.ts
+++ b/examples/solana/policies/createSplTokenLimitsPolicy.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
 });
 

--- a/examples/solana/signing/signMessage.ts
+++ b/examples/solana/signing/signMessage.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/solana/signing/signTransaction.ts
+++ b/examples/solana/signing/signTransaction.ts
@@ -15,7 +15,7 @@ import {
 } from "@solana/kit";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
 });

--- a/examples/solana/transactions/sendRawTransaction.ts
+++ b/examples/solana/transactions/sendRawTransaction.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
   publishableKey: process.env.OPENFORT_PUBLISHABLE_KEY,

--- a/examples/solana/transactions/sendTransaction.ts
+++ b/examples/solana/transactions/sendTransaction.ts
@@ -8,7 +8,7 @@ import { getTransferSolInstruction } from "@solana-program/system";
 import { address, createNoopSigner } from "@solana/kit";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
   publishableKey: process.env.OPENFORT_PUBLISHABLE_KEY,

--- a/examples/solana/transactions/transfer.ts
+++ b/examples/solana/transactions/transfer.ts
@@ -3,7 +3,7 @@
 import Openfort from "@openfort/openfort-node";
 import "dotenv/config";
 
-const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
   basePath: process.env.OPENFORT_BASE_URL,
   walletSecret: process.env.OPENFORT_WALLET_SECRET,
   publishableKey: process.env.OPENFORT_PUBLISHABLE_KEY,

--- a/examples/webhook/index.ts
+++ b/examples/webhook/index.ts
@@ -17,7 +17,7 @@ app.post(
 	"/webhook/openfort",
 	express.raw({ type: "application/json" }),
 	async (req: Request, res: Response) => {
-		const openfort = new Openfort(process.env.OPENFORT_API_KEY!, {
+		const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY!, {
 			basePath: process.env.OPENFORT_BASE_URL,
 		});
 		try {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,7 +13,7 @@ Missing required Openfort API key.
 
 You can set it as an environment variable:
 
-OPENFORT_API_KEY=sk_test_...
+OPENFORT_SECRET_KEY=sk_test_...
 
 You can also pass it to the constructor:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ function isValidPublishableKey(key: string): boolean {
  * Provides access to all Openfort API endpoints and wallet functionality.
  *
  * Environment variables (all optional, constructor options take precedence):
- * - `OPENFORT_API_KEY` - Secret API key (sk_test_... or sk_live_...)
+ * - `OPENFORT_SECRET_KEY` - Secret API key (sk_test_... or sk_live_...)
  * - `OPENFORT_WALLET_SECRET` - Wallet secret for backend wallet operations
  * - `OPENFORT_PUBLISHABLE_KEY` - Publishable key for auth endpoints (pk_test_... or pk_live_...)
  * - `OPENFORT_BASE_URL` - Custom API base URL
@@ -131,7 +131,7 @@ class Openfort {
 
   constructor(apiKey?: string, options?: string | OpenfortOptions) {
     // Resolve API key: explicit parameter > environment variable
-    const resolvedApiKey = apiKey || process.env.OPENFORT_API_KEY
+    const resolvedApiKey = apiKey || process.env.OPENFORT_SECRET_KEY
 
     // Resolve options
     const resolvedBasePath =


### PR DESCRIPTION
## Summary

Standardizes environment variable names to their canonical forms across the repo. Each variable keeps its existing prefix; only the base token changes. **No values were changed.**

## Renames applied

| Old | New | Occurrences |
| --- | --- | --- |
| `OPENFORT_API_KEY` | `OPENFORT_SECRET_KEY` | 55 |
| `SHIELD_API_KEY` | `SHIELD_PUBLISHABLE_KEY` | 3 |
| `SHIELD_API_SECRET` | `SHIELD_SECRET_KEY` | 3 |
| `SHIELD_ENCRYPTION_SHARE` | `SHIELD_ENCRYPTION_KEY` | 3 |

Applied as whole-word, case-sensitive replacements across `examples/.env.example`, all example sources, `examples/README.md`, and the `src/` files that read these via `process.env`. 54 files changed, 64 insertions / 64 deletions.

Untouched (already canonical or out of scope): `OPENFORT_PUBLISHABLE_KEY`, `OPENFORT_WALLET_SECRET`, `OPENFORT_BASE_URL`. SDK option keys (`shieldApiKey`, `shieldApiSecret`) are TS object properties, not env vars, and were intentionally left as-is.

## Manual update required

Anyone with a local `.env` (or CI/deployment secrets) must rename their environment variables to the new names. The `.github/workflows/` files do not reference any of these variables, so no workflow changes were needed. This package is not deployed under an openfort.io subdomain, so no Vercel changes are expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)