### PR TITLE
ci(release): fetch full history for Changesets changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Fetch full history so Changesets can resolve the commit behind
+          # each changeset when generating changelog entries (avoids flaky
+          # GitHub API lookups against a shallow clone).
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4


### PR DESCRIPTION
## Problem

After #129 merged, the `Release` workflow failed in `changeset version`:

```
🦋  error Error: Failed to parse data from GitHub
🦋  error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
    at @changesets/get-github-info/dist/changesets-get-github-info.cjs.js:185:11
```

`pnpm install --lockfile-only` succeeded; the failure was in `@changesets/changelog-github` generating changelog entries.

## Root cause

The `Checkout repository` step uses the default **shallow** clone (`fetch-depth: 1`). With only the tip commit available, `@changesets/changelog-github` can't reliably resolve the commit that introduced each changeset and its GitHub GraphQL lookup is fragile — here it dropped mid-response (`Premature close`).

## Fix

Fetch full history in the release checkout so changelog generation is deterministic:

```yaml
      - name: Checkout repository
        uses: actions/checkout@... # v6
        with:
          fetch-depth: 0
```

This is the standard Changesets requirement for changelog generation. The `.changeset/update-dependencies-audit.md` from #129 is still pending, so merging this will let the next `Release` run version it cleanly.

## Note

This is a workflow-robustness fix only — no package or lockfile changes.
