### PR TITLE
fix(evm): chain-aware EIP-7702 implementationType in backend sendTransaction (unblock Amoy)

### DIFF
--- a/.changeset/chain-aware-7702-impl-type.md
+++ b/.changeset/chain-aware-7702-impl-type.md
@@ -1,0 +1,7 @@
+---
+'@openfort/openfort-node': patch
+---
+
+Fix EVM backend `sendTransaction` EIP-7702 delegation on chains where the `Calibur` implementation type is not available (e.g. Polygon Amoy / 80002).
+
+The register-on-first-send path previously hardcoded `implementationType: "Calibur"`, which is rejected on Amoy with `not available in chainId '80002'`. It now uses a chain-aware default (`CaliburV9`, available on Amoy) and falls back to `Calibur` only on chains where `CaliburV9` is not available (Ethereum Mainnet / 1). Callers can override per call via the new `SendTransactionOptions.implementationType`.

--- a/src/wallets/evm/actions/sendTransaction.test.ts
+++ b/src/wallets/evm/actions/sendTransaction.test.ts
@@ -30,7 +30,11 @@ vi.mock('viem', () => ({
   })),
 }))
 
-vi.mock('viem/chains', () => ({ baseSepolia: { id: 84532 } }))
+vi.mock('viem/chains', () => ({
+  baseSepolia: { id: 84532 },
+  polygonAmoy: { id: 80002 },
+  mainnet: { id: 1 },
+}))
 
 vi.mock('viem/utils', () => ({ hashAuthorization: mocks.hashAuthorization }))
 
@@ -198,5 +202,64 @@ describe('sendTransaction — EIP-7702 authorization gating', () => {
     const intentArg = mocks.createTransactionIntent.mock.calls[0][0]
     expect(intentArg.account).toBe('acc_new_del')
     expect(intentArg.signedAuthorization).toBe('0xsignature')
+  })
+
+  it('registers with the chain-aware default (CaliburV9) on first send', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [] })
+    mocks.update.mockResolvedValue({ id: 'acc_new_del' })
+    mocks.getCode.mockResolvedValue(undefined)
+
+    const account = makeAccount()
+    await sendTransaction(opts(account)) // baseSepolia (84532)
+
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({ implementationType: 'CaliburV9' }),
+    )
+  })
+
+  it('registers with CaliburV9 on Polygon Amoy (80002), where V8 Calibur is not deployed', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [] })
+    mocks.update.mockResolvedValue({ id: 'acc_new_del' })
+    mocks.getCode.mockResolvedValue(undefined)
+
+    const account = makeAccount()
+    await sendTransaction({ ...opts(account), chainId: 80002 })
+
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        implementationType: 'CaliburV9',
+        chainId: 80002,
+      }),
+    )
+  })
+
+  it('falls back to V8 Calibur on Ethereum Mainnet (1), where CaliburV9 is not deployed', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [] })
+    mocks.update.mockResolvedValue({ id: 'acc_new_del' })
+    mocks.getCode.mockResolvedValue(undefined)
+
+    const account = makeAccount()
+    await sendTransaction({ ...opts(account), chainId: 1 })
+
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({ implementationType: 'Calibur', chainId: 1 }),
+    )
+  })
+
+  it('registers with an explicit implementationType override when provided', async () => {
+    mocks.getAccountsV2.mockResolvedValue({ data: [] })
+    mocks.update.mockResolvedValue({ id: 'acc_new_del' })
+    mocks.getCode.mockResolvedValue(undefined)
+
+    const account = makeAccount()
+    await sendTransaction({
+      ...opts(account),
+      chainId: 1,
+      implementationType: 'CaliburV9',
+    })
+
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({ implementationType: 'CaliburV9' }),
+    )
   })
 })

--- a/src/wallets/evm/actions/sendTransaction.ts
+++ b/src/wallets/evm/actions/sendTransaction.ts
@@ -13,6 +13,36 @@ import type {
   TransactionIntentResponse,
 } from '../types'
 import { update } from './updateToDelegated'
+
+/**
+ * Default EIP-7702 implementation type registered on the first send when an
+ * account has no delegated record yet.
+ *
+ * `CaliburV9` is accepted on every chain the older `Calibur` type supports plus
+ * Polygon Amoy (80002), so it is the portable default. `Calibur` alone is
+ * rejected on Amoy (the API returns `not available in chainId '80002'`).
+ */
+const DEFAULT_DELEGATION_IMPLEMENTATION_TYPE = 'CaliburV9'
+
+/**
+ * Chains where `CaliburV9` is not available and the older `Calibur` type must be
+ * used instead. Kept minimal and explicit; callers can always override via
+ * `SendTransactionOptions.implementationType`.
+ *
+ * - `1` — Ethereum Mainnet: `Calibur` only.
+ */
+const CHAINS_REQUIRING_CALIBUR_V8: ReadonlySet<number> = new Set([1])
+
+/**
+ * The default EIP-7702 implementation type for a chain, used when the caller
+ * does not pass one explicitly. See {@link DEFAULT_DELEGATION_IMPLEMENTATION_TYPE}.
+ */
+function defaultImplementationTypeForChain(chainId: number): string {
+  return CHAINS_REQUIRING_CALIBUR_V8.has(chainId)
+    ? 'Calibur'
+    : DEFAULT_DELEGATION_IMPLEMENTATION_TYPE
+}
+
 /**
  * Delegates an EVM account via EIP-7702 and sends a gasless transaction in one call.
  *
@@ -63,6 +93,8 @@ export async function sendTransaction(
   }
 
   const { account, chainId, interactions, policy, rpcUrl } = options
+  const implementationType =
+    options.implementationType ?? defaultImplementationTypeForChain(chainId)
 
   // 1. Resolve chain + RPC
   // This RPC gates EIP-7702 authorization signing, so require a trusted scheme:
@@ -123,7 +155,7 @@ export async function sendTransaction(
     const updated = await update({
       walletId: account.walletId,
       chainId,
-      implementationType: 'Calibur',
+      implementationType,
       accountId: account.id,
     })
     txAccountId = updated.id

--- a/src/wallets/evm/types.ts
+++ b/src/wallets/evm/types.ts
@@ -170,6 +170,20 @@ export interface SendTransactionOptions {
   policy?: string
   /** Custom RPC URL. If omitted, uses viem's default public RPC for the chain. */
   rpcUrl?: string
+  /**
+   * EIP-7702 implementation type to register when the account has no delegated
+   * record yet (the register-on-first-send path). Optional.
+   *
+   * When omitted, a chain-aware default is used: `"CaliburV9"` on every chain
+   * where it is deployed (including Polygon Amoy / 80002), falling back to
+   * `"Calibur"` (V8) on the chains where V9 is not available (e.g. Ethereum
+   * Mainnet / 1). Set this explicitly to override the default for a chain — for
+   * example if a newer implementation type ships before this SDK is updated.
+   *
+   * Ignored when a delegated-account record already exists (the existing
+   * record's implementation is authoritative).
+   */
+  implementationType?: string
 }
 
 // Re-export viem types for convenience


### PR DESCRIPTION
## Problem

EIP-7702 delegation fails in the server-side backend EVM account `sendTransaction` flow on chains where the `Calibur` implementation type is not available — notably **Polygon Amoy (80002)**, where the API rejects the request with:

> `not available in chainId '80002'`

Root cause: the register-on-first-send path in `sendTransaction` **hardcodes** `implementationType: 'Calibur'`:

```ts
// src/wallets/evm/actions/sendTransaction.ts (before)
const updated = await update({ walletId, chainId, implementationType: 'Calibur', accountId })
```

`Calibur` is not available on Amoy, so the API rejects it. `CaliburV9` **is** available there, but the SDK never asks for it — so Amoy delegation is unreachable through this flow.

## Fix

- **Chain-aware default.** The first-send registration now defaults to `CaliburV9`, which is available on Amoy plus every chain `Calibur` supports. It falls back to `Calibur` only on chains where `CaliburV9` is not available (Ethereum Mainnet / `1`), so mainnet delegation does not regress.
- **Per-call override.** New optional `SendTransactionOptions.implementationType` lets callers pick the implementation explicitly.

Only affects the path where **no delegated-account record exists yet**. When a record already exists, its implementation address remains authoritative (unchanged).

```ts
// override example
await openfort.accounts.evm.backend.sendTransaction({
  account, chainId: 80002, interactions,
  implementationType: 'CaliburV9', // optional; now also the default on Amoy
})
```

## Tests

`src/wallets/evm/actions/sendTransaction.test.ts` — added coverage for: default `CaliburV9` on Base Sepolia, `CaliburV9` on Amoy (80002), `Calibur` fallback on mainnet (1), and explicit override. Full file: **14 passed**. `tsc --noEmit` clean; biome formatted.

Prompted by: Jaume Alavedra
