### PR TITLE
types: document evmData criterion args and sendTransaction policy param

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -523,6 +523,13 @@ class Openfort {
    * Transaction intents represent a desired on-chain action (contract calls, transfers).
    * When a fee sponsorship policy is provided (or auto-discovered from project-scoped policies),
    * gas costs are sponsored according to the policy's strategy.
+   *
+   * The `policy` field accepted by `create` is a fee-sponsorship ID (starts
+   * with `pol_`, from `openfort.feeSponsorship.create()`), not a guardrail
+   * policy ID (`ply_`, from `openfort.policies.create()`). Guardrail policies
+   * are attached by scope and enforced automatically; a guardrail policy that
+   * gets linked to a fee sponsorship (via `feeSponsorship.create({ policyId })`)
+   * governs sponsorship eligibility instead of acting as a signing guardrail.
    */
   public get transactionIntents() {
     if (!this._evmClient) {

--- a/src/policies/evmSchema.ts
+++ b/src/policies/evmSchema.ts
@@ -107,11 +107,36 @@ export type EvmMessageCriterion = z.infer<typeof EvmMessageCriterionSchema>
 export const EvmDataCriterionSchema = z.object({
   type: z.literal('evmData'),
   operator: EvmDataOperatorEnum,
-  /** Contract ABI as JSON string. */
+  /** Contract ABI as a JSON-stringified string. Typically a single-function ABI fragment covering just `functionName`. */
   abi: z.string().min(1),
   /** Function name to match. */
   functionName: z.string().min(1),
-  /** Argument constraints. */
+  /**
+   * Constraints on the function's decoded arguments, keyed by argument name
+   * (as declared in `abi`). Kept as `Record<string, unknown>` because the
+   * value shape depends on `operator` and is not uniform across all of them:
+   * membership operators (`in`, `not in`) expect an array of allowed values,
+   * while comparison operators (`<`, `<=`, `>`, `>=`, `==`) and `match` expect
+   * a single scalar value.
+   *
+   * Verified worked example — allowlist ERC-20 `transfer` recipients:
+   * ```ts
+   * {
+   *   type: 'evmData',
+   *   operator: 'in',
+   *   abi: JSON.stringify([{
+   *     type: 'function',
+   *     name: 'transfer',
+   *     inputs: [
+   *       { name: 'to', type: 'address' },
+   *       { name: 'value', type: 'uint256' },
+   *     ],
+   *   }]),
+   *   functionName: 'transfer',
+   *   args: { to: ['0x...', '0x...'] },
+   * }
+   * ```
+   */
   args: z.record(z.unknown()).optional(),
 })
 /** A criterion that validates transaction calldata against a contract ABI, function name, and argument constraints. */

--- a/src/wallets/evm/actions/sendTransaction.ts
+++ b/src/wallets/evm/actions/sendTransaction.ts
@@ -49,7 +49,8 @@ function defaultImplementationTypeForChain(chainId: number): string {
  * eth_getCode -> if the EOA is not delegated on-chain, hashes and signs an EIP-7702
  * authorization -> creates transaction intent -> signs and submits if needed.
  *
- * @param options - Transaction options including account ID, chain, interactions, and optional policy
+ * @param options - Transaction options including account ID, chain, interactions, and an
+ * optional fee-sponsorship policy (see {@link SendTransactionOptions.policy})
  * @returns The transaction intent response
  *
  * @example
@@ -58,7 +59,7 @@ function defaultImplementationTypeForChain(chainId: number): string {
  *   id: 'acc_...',
  *   chainId: 84532,
  *   interactions: [{ to: '0x...', data: '0x...' }],
- *   policy: 'pol_...',
+ *   policy: 'pol_...', // fee-sponsorship policy id, not a guardrail policy id
  * });
  * console.log(result.response?.transactionHash);
  * ```

--- a/src/wallets/evm/types.ts
+++ b/src/wallets/evm/types.ts
@@ -166,7 +166,18 @@ export interface SendTransactionOptions {
   chainId: number
   /** Contract interactions to execute */
   interactions: Interaction[]
-  /** Policy ID for gas sponsorship (starts with pol_). Optional. */
+  /**
+   * Fee-sponsorship policy ID (starts with `pol_`), obtained from
+   * `openfort.feeSponsorship.create()`. Optional — when omitted, project-scoped
+   * fee sponsorships are auto-discovered and the first matching one is applied.
+   *
+   * This is NOT a guardrail policy ID (starts with `ply_`, from
+   * `openfort.policies.create()`). Guardrail policies are attached by scope
+   * (project- or account-wide) and enforced automatically on every operation —
+   * they are never passed here. Linking a guardrail policy to a fee sponsorship
+   * (via `feeSponsorship.create({ policyId })`) makes it govern sponsorship
+   * eligibility instead; it no longer acts as a signing guardrail.
+   */
   policy?: string
   /** Custom RPC URL. If omitted, uses viem's default public RPC for the chain. */
   rpcUrl?: string


### PR DESCRIPTION
## Summary

- `EvmDataCriterionSchema.args` (in `src/policies/evmSchema.ts`) now has JSDoc explaining that the value shape depends on `operator` — an array of allowed values for membership operators (`in`, `not in`), a single scalar for comparison operators and `match` — with a worked example allowlisting an ERC-20 `transfer` recipient. The type itself stays `Record<string, unknown>`: the existing test suite already exercises both array and scalar `args` values (`policies.test.ts`), so narrowing the type further would overconstrain a shape that isn't uniform across operators.
- The `policy` field on `SendTransactionOptions` (`src/wallets/evm/types.ts`), the `accounts.evm.backend.sendTransaction` JSDoc (`src/wallets/evm/actions/sendTransaction.ts`), and the `transactionIntents` section (`src/index.ts`) now make explicit that `policy` is a fee-sponsorship policy id (`pol_...`, from `feeSponsorship.create()`), not a guardrail policy id (`ply_...`, from `policies.create()`). Guardrail policies are attached by scope and enforced automatically; linking one to a fee sponsorship makes it govern sponsorship eligibility instead of acting as a signing guardrail.

Both `EvmDataCriterionSchema` and `SendTransactionOptions`/`sendTransaction` live in the handwritten SDK layer (`src/policies`, `src/wallets`), not in the orval-generated `src/openapi-client/generated` tree, so these are documentation-only changes with no generated code to keep in sync.

The `evmData` `args` shape (array for `in`) and the fee-sponsorship-vs-guardrail-policy distinction were verified against the live API before writing this JSDoc.

## Test plan

- [x] `pnpm lint` (biome)
- [x] `pnpm check:types` (tsc --noEmit)
- [x] `pnpm test` (vitest — 100 tests passed)
- [x] `pnpm build` (tsup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)